### PR TITLE
Fix compilation errors with latest types

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,5 +26,6 @@ registerPlugin({
     authors: ['OpenRCT2'],
     type: 'intransient',
     licence: 'MIT',
+    targetApiVersion: 52,
     main: main
 });

--- a/src/titleEditorWindow.ts
+++ b/src/titleEditorWindow.ts
@@ -500,7 +500,7 @@ class TitleEditorWindow {
         }
 
         const seqDropdown = this.window.findWidget<DropdownWidget>('dropdown-sequence');
-        if (seqDropdown) {
+        if (seqDropdown && this.currentSequence !== undefined) {
             seqDropdown.selectedIndex = this.currentSequence;
         }
     }


### PR DESCRIPTION
Fixes #7

I got the value for `targetApiVersion` by comparing the dates in these two commits:

https://github.com/OpenRCT2/title-sequence-editor/commit/b6bec25413a06d4e35ab6750520d62d2073ba11b

https://github.com/OpenRCT2/OpenRCT2/commit/372606ab9afae880c91f59247d305928f2e6ebcc